### PR TITLE
HangulView 심볼버튼에 쉼표(,) 추가

### DIFF
--- a/keyboard/HangulView.swift
+++ b/keyboard/HangulView.swift
@@ -177,10 +177,10 @@ struct HangulView: View {
         onLongPressFinished: {
           lastLongPressKey = ""
         })
-        KeyboardButton(text: ".?!", primary: false, action: {
+        KeyboardButton(text: ".,?!", primary: false, action: {
           Feedback.shared.playTypeSound()
           Feedback.shared.playHaptics()
-          options.textAction(".", "?", "!")
+          options.textAction(".", ",", "?", "!")
         })
       }
       HStack {


### PR DESCRIPTION
안녕하세요! 블로그를 통해 알게된 앱으로 현재 아이폰을 편리하게 사용하고 있습니다. 감사하다는 말 먼저 전해드립니다 🥰

삼성과 달리 키보드에 있는 심볼버튼인 `.?!` 부분에서 쉼표(,)가 없어 사용하는데 어려움이 발생하고 있습니다.

![삼성 키보드](https://github.com/anaclumos/sky-earth-human/assets/50764666/008ea613-4bf8-44a0-b911-1c5b9042d91b)

따라서 해당 PR를 올려봤습니다만, 테스트를 할 환경이 되지않아 못하였습니다 🥺